### PR TITLE
Add tto:color missing property in the ontology

### DIFF
--- a/default/ttl-data/ontology.ttl
+++ b/default/ttl-data/ontology.ttl
@@ -69,3 +69,9 @@ tto:weight
 	rdfs:range xsd:decimal ;
 	rdfs:isDefinedBy tto: . 
 
+tto:color
+	rdf:type rdf:Property;
+	rdfs:label "color"^^xsd:string;
+	rdfs:domain dbo:Animal ;
+	rdfs:range xsd:string ;
+	rdfs:isDefinedBy tto: .


### PR DESCRIPTION
In the ontology it is not present the **tto:color** property. The PR fix the missing property.